### PR TITLE
Strip "/index" part from page url for sitemap

### DIFF
--- a/Classes/Plugin.php
+++ b/Classes/Plugin.php
@@ -26,9 +26,10 @@ class Plugin extends \Phile\Plugin\AbstractPlugin implements \Phile\Gateway\Even
 				header('Content-Type: application/xml; charset=UTF-8');
 				$xml = '<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
 				foreach( $pages as $page ){
+					$pageUrl = preg_replace('/(^|\/)index$/', '', $page->getUrl());
 					$lastMod = filemtime($page->getFilePath());
 					$xml .= '<url>
-								<loc>' . \Phile\Utility::getBaseUrl() . '/' . $page->getUrl() . '</loc>
+								<loc>' . \Phile\Utility::getBaseUrl() . '/' . $pageUrl . '</loc>
 								<lastmod>' . strftime('%Y-%m-%d', $lastMod) . '</lastmod>
 							</url>';
 				}

--- a/Classes/Plugin.php
+++ b/Classes/Plugin.php
@@ -3,37 +3,38 @@
  * Plugin class
  */
 namespace Phile\Plugin\Phile\XmlSitemap;
+
 /**
  * XML Sitemap Plugin
  */
 class Plugin extends \Phile\Plugin\AbstractPlugin implements \Phile\Gateway\EventObserverInterface {
+
 	public function __construct() {
 		\Phile\Event::registerEvent('plugins_loaded', $this);
 	}
 
 	public function on($eventKey, $data = null) {
-		
 		// check $eventKey for which you have registered
 		if ($eventKey == 'plugins_loaded') {
-			$uri    = $_SERVER['REQUEST_URI'];
-			$uri    = str_replace('/' . \Phile\Utility::getInstallPath(), '', $uri);
+			$uri = $_SERVER['REQUEST_URI'];
+			$uri = str_replace('/' . \Phile\Utility::getInstallPath(), '', $uri);
 			if ($uri == '/sitemap.xml') {
-			 	$pageRespository = new \Phile\Repository\Page();
-				$pages  = $pageRespository->findAll();
-			 	
-			 	header($_SERVER['SERVER_PROTOCOL'].' 200 OK');
+				$pageRespository = new \Phile\Repository\Page();
+				$pages = $pageRespository->findAll();
+
+				header($_SERVER['SERVER_PROTOCOL'] . ' 200 OK');
 				header('Content-Type: application/xml; charset=UTF-8');
 				$xml = '<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
-                foreach( $pages as $page ){
-	                $lastMod    = filemtime($page->getFilePath());
+				foreach( $pages as $page ){
+					$lastMod = filemtime($page->getFilePath());
 					$xml .= '<url>
-								<loc>'. \Phile\Utility::getBaseUrl() . '/' . $page->getUrl().'</loc>
-								<lastmod>'.strftime('%Y-%m-%d', $lastMod).'</lastmod>
+								<loc>' . \Phile\Utility::getBaseUrl() . '/' . $page->getUrl() . '</loc>
+								<lastmod>' . strftime('%Y-%m-%d', $lastMod) . '</lastmod>
 							</url>';
-                }
-                $xml .= '</urlset>';
-                header('Content-Type: text/xml');
-                echo $xml;
+				}
+				$xml .= '</urlset>';
+				header('Content-Type: text/xml');
+				echo $xml;
 				exit;
 			}
 		}


### PR DESCRIPTION
I stripped "/index" part from URLs from pages which are subfolders (ex. `/sub/index`) and from main page (`index`) - I'd rather have `http://example.com/` and `http://example.com/sub` in sitemap than `http://example.com/index` and `http://example.com/sub/index`. I also fixed inconsistencies in whitespace in the plugin file.
